### PR TITLE
fix fileleak route type error

### DIFF
--- a/app/routes/fileleak.py
+++ b/app/routes/fileleak.py
@@ -11,7 +11,7 @@ base_search_fields = {
     'site': fields.String(description="站点"),
     'content_length': fields.Integer(description="body 长度"),
     'status_code': fields.Integer(description="状态码"),
-    'title': fields.Integer(description="标题"),
+    'title': fields.String(description="标题"),
     "task_id": fields.String(description="任务ID")
 }
 


### PR DESCRIPTION
## 文件泄露页面搜索页面 title 类型不正确，导致服务400
url:
http://192.168.233.xxx:5003/api/fileleak/?page=1&size=10&title=Swagger+UI&task_id=5fad705b2bdxxxxxxx532790
response:
{"errors": {"title": "\u6807\u9898 invalid literal for int() with base 10: 'Swagger UI'"}, "message": "Input payload validation failed"}