### PR TITLE
`unicode` was removed in Python 3

### DIFF
--- a/app/utils/nmap.py
+++ b/app/utils/nmap.py
@@ -537,10 +537,7 @@ class PortScanner(object):
         """
         returns a host detail
         """
-        if sys.version_info[0] == 2:
-            assert type(host) in (str, unicode), 'Wrong type for [host], should be a string [was {0}]'.format(type(host))
-        else:
-            assert type(host) is str, 'Wrong type for [host], should be a string [was {0}]'.format(type(host))
+        assert type(host) in (str, unicode), 'Wrong type for [host], should be a string [was {0}]'.format(type(host))
         return self._scan_result['scan'][host]
 
     def all_hosts(self):
@@ -731,14 +728,9 @@ class PortScannerAsync(object):
         :param sudo: launch nmap with sudo if true
         """
 
-        if sys.version_info[0] == 2:
-            assert type(hosts) in (str, unicode), 'Wrong type for [hosts], should be a string [was {0}]'.format(type(hosts))
-            assert type(ports) in (str, unicode, type(None)), 'Wrong type for [ports], should be a string [was {0}]'.format(type(ports))
-            assert type(arguments) in (str, unicode), 'Wrong type for [arguments], should be a string [was {0}]'.format(type(arguments))
-        else:
-            assert type(hosts) is str, 'Wrong type for [hosts], should be a string [was {0}]'.format(type(hosts))
-            assert type(ports) in (str, type(None)), 'Wrong type for [ports], should be a string [was {0}]'.format(type(ports))
-            assert type(arguments) is str, 'Wrong type for [arguments], should be a string [was {0}]'.format(type(arguments))
+        assert type(hosts) in (str, unicode), 'Wrong type for [hosts], should be a string [was {0}]'.format(type(hosts))
+        assert type(ports) in (str, unicode, type(None)), 'Wrong type for [ports], should be a string [was {0}]'.format(type(ports))
+        assert type(arguments) in (str, unicode), 'Wrong type for [arguments], should be a string [was {0}]'.format(type(arguments))
 
         assert callable(callback) or callback is None, 'The [callback] {0} should be callable or None.'.format(str(callback))
 

--- a/app/utils/nmap.py
+++ b/app/utils/nmap.py
@@ -63,6 +63,10 @@ except ImportError:
     # For pre 2.6 releases
     from threading import Thread as Process
 
+try:
+    unicode
+except NameError:
+    unicode = str
 
 __author__ = 'Alexandre Norman (norman@xael.org)'
 __version__ = '0.6.3'
@@ -207,14 +211,9 @@ class PortScanner(object):
 
         :returns: scan_result as dictionnary
         """
-        if sys.version_info[0] == 2:
-            assert type(hosts) in (str, unicode), 'Wrong type for [hosts], should be a string [was {0}]'.format(type(hosts))  # noqa
-            assert type(ports) in (str, unicode, type(None)), 'Wrong type for [ports], should be a string [was {0}]'.format(type(ports))  # noqa
-            assert type(arguments) in (str, unicode), 'Wrong type for [arguments], should be a string [was {0}]'.format(type(arguments))  # noqa
-        else:
-            assert type(hosts) is str, 'Wrong type for [hosts], should be a string [was {0}]'.format(type(hosts))  # noqa
-            assert type(ports) in (str, type(None)), 'Wrong type for [ports], should be a string [was {0}]'.format(type(ports))  # noqa
-            assert type(arguments) is str, 'Wrong type for [arguments], should be a string [was {0}]'.format(type(arguments))  # noqa
+        assert type(hosts) in (str, unicode), 'Wrong type for [hosts], should be a string [was {0}]'.format(type(hosts))
+        assert type(ports) in (str, unicode, type(None)), 'Wrong type for [ports], should be a string [was {0}]'.format(type(ports))
+        assert type(arguments) in (str, unicode), 'Wrong type for [arguments], should be a string [was {0}]'.format(type(arguments))
 
         for redirecting_output in ['-oX', '-oA']:
             assert redirecting_output not in arguments, 'Xml output can\'t be redirected from command line.\nYou can access it after a scan using:\nnmap.nm.get_nmap_last_output()'  # noqa


### PR DESCRIPTION
Simplify the logic by defining `unicode` to be `str` in Python 3 where all strings are Unicode by default.