### PR TITLE
使用第三方源的GeoLite2-City更新

### DIFF
--- a/.github/workflows/arm-builder.yml
+++ b/.github/workflows/arm-builder.yml
@@ -33,8 +33,8 @@ jobs:
         run: |
           pwd
           mkdir -p docker/GeoLite2/
-          wget -O docker/GeoLite2/GeoLite2-ASN.mmdb  https://github.com/1c3z/arl_files/raw/master/GeoLite2-ASN.mmdb
-          wget -O docker/GeoLite2/GeoLite2-City.mmdb  https://github.com/1c3z/arl_files/raw/master/GeoLite2-City.mmdb
+          wget -O docker/GeoLite2/GeoLite2-ASN.mmdb  https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-ASN.mmdb
+          wget -O docker/GeoLite2/GeoLite2-City.mmdb  https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-City.mmdb
           ls -al docker/GeoLite2
 
       - name: Download NPoC

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,8 @@ jobs:
         run: |
           pwd
           mkdir -p docker/GeoLite2/
-          wget -O docker/GeoLite2/GeoLite2-ASN.mmdb  https://github.com/1c3z/arl_files/raw/master/GeoLite2-ASN.mmdb
-          wget -O docker/GeoLite2/GeoLite2-City.mmdb  https://github.com/1c3z/arl_files/raw/master/GeoLite2-City.mmdb
+          wget -O docker/GeoLite2/GeoLite2-ASN.mmdb  https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-ASN.mmdb
+          wget -O docker/GeoLite2/GeoLite2-City.mmdb  https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-City.mmdb
           ls -al docker/GeoLite2
 
       - name: Download ncrack

--- a/misc/setup-arl.sh
+++ b/misc/setup-arl.sh
@@ -84,12 +84,12 @@ fi
 mkdir -p /data/GeoLite2
 if [ ! -f /data/GeoLite2/GeoLite2-ASN.mmdb ]; then
   echo "download GeoLite2-ASN.mmdb ..."
-  wget https://github.com/1c3z/arl_files/raw/master/GeoLite2-ASN.mmdb -O /data/GeoLite2/GeoLite2-ASN.mmdb
+  wget https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-ASN.mmdb -O /data/GeoLite2/GeoLite2-ASN.mmdb
 fi
 
 if [ ! -f /data/GeoLite2/GeoLite2-City.mmdb ]; then
   echo "download GeoLite2-City.mmdb ..."
-  wget https://github.com/1c3z/arl_files/raw/master/GeoLite2-City.mmdb -O /data/GeoLite2/GeoLite2-City.mmdb
+  wget https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-City.mmdb -O /data/GeoLite2/GeoLite2-City.mmdb
 fi
 
 cd ARL


### PR DESCRIPTION
来源：
https://github.com/P3TERX/GeoLite.mmdb
通过github历史信息来看该库貌似已经稳定运行2 years ago 通过Github CI 每日更新 如果不放心可以 将ci脚本clone下来部署自己的LICENSE_KEY 更新 关于LICENSE_KEY似乎只需要注册即可

- 试图解决 Closes #424